### PR TITLE
Add custom user models and service layer

### DIFF
--- a/apps/common/repositories/user_repository.py
+++ b/apps/common/repositories/user_repository.py
@@ -1,6 +1,9 @@
 from typing import List, Optional
-from django.contrib.auth.models import User
+from django.contrib.auth import get_user_model
 from .base import BaseRepository
+
+User = get_user_model()
+
 
 class UserRepository(BaseRepository[User]):
     """

--- a/apps/common/services/__init__.py
+++ b/apps/common/services/__init__.py
@@ -1,0 +1,1 @@
+"""Service layer modules."""

--- a/apps/common/services/base.py
+++ b/apps/common/services/base.py
@@ -1,0 +1,32 @@
+from abc import ABC
+from typing import Generic, TypeVar
+from apps.common.repositories.base import BaseRepository
+
+T = TypeVar('T')
+
+
+class BaseService(Generic[T], ABC):
+    """Base service providing CRUD operations via a repository."""
+
+    repository_class: type[BaseRepository]
+
+    def __init__(self, repository: BaseRepository | None = None) -> None:
+        self.repository = repository or self.repository_class()
+
+    def get_by_id(self, pk: int) -> T | None:
+        return self.repository.get_by_id(pk)
+
+    def get_all(self):
+        return self.repository.get_all()
+
+    def create(self, **kwargs) -> T:
+        return self.repository.create(**kwargs)
+
+    def update(self, instance: T, **kwargs) -> T:
+        return self.repository.update(instance, **kwargs)
+
+    def delete(self, instance: T) -> None:
+        self.repository.delete(instance)
+
+    def filter(self, **filters):
+        return self.repository.filter(**filters)

--- a/apps/common/services/user_service.py
+++ b/apps/common/services/user_service.py
@@ -1,0 +1,17 @@
+from django.contrib.auth import get_user_model
+from apps.common.repositories.user_repository import UserRepository
+from .base import BaseService
+
+User = get_user_model()
+
+
+class UserService(BaseService[User]):
+    """Service layer for user-related operations."""
+
+    repository_class = UserRepository
+
+    def get_active_users(self):
+        return self.repository.get_active_users()
+
+    def get_staff_users(self):
+        return self.repository.get_staff_users()

--- a/apps/core/__init__.py
+++ b/apps/core/__init__.py
@@ -1,0 +1,3 @@
+"""Core application with custom user and profile models."""
+
+__all__ = ["User", "UserProfile"]

--- a/apps/core/models.py
+++ b/apps/core/models.py
@@ -1,0 +1,28 @@
+from django.contrib.auth.models import AbstractUser
+from django.db import models
+
+
+class User(AbstractUser):
+    """Custom user model with unique email."""
+    email = models.EmailField(unique=True)
+
+
+class UserProfile(models.Model):
+    """Profile model linked to :class:`User`."""
+    user = models.OneToOneField(User, on_delete=models.CASCADE, related_name="profile")
+    bio = models.TextField(blank=True)
+    phone_number = models.CharField(max_length=20, blank=True)
+
+    def __str__(self) -> str:
+        return f"Profile of {self.user.username}"
+
+
+# Automatically create a profile when a user is created
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+
+@receiver(post_save, sender=User)
+def create_user_profile(sender, instance, created, **kwargs):
+    if created:
+        UserProfile.objects.create(user=instance)

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -42,8 +42,12 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'apps.core',
 ]
 INSTALLED_APPS += env.list("EXTRA_APPS", default=[])
+
+# Custom user model
+AUTH_USER_MODEL = 'core.User'
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',

--- a/tests/unit/models/test_user_models.py
+++ b/tests/unit/models/test_user_models.py
@@ -1,0 +1,16 @@
+import pytest
+from django.test import TestCase
+from apps.core.models import User, UserProfile
+
+
+class TestUserAndProfile(TestCase):
+    def test_profile_created_on_user_creation(self):
+        user = User.objects.create_user(username='john', email='john@example.com', password='pass')
+        profile = UserProfile.objects.get(user=user)
+        assert profile.user == user
+
+    def test_profile_deleted_with_user(self):
+        user = User.objects.create_user(username='jane', email='jane@example.com', password='pass')
+        user_id = user.id
+        user.delete()
+        assert not UserProfile.objects.filter(user_id=user_id).exists()

--- a/tests/unit/services/test_base_service.py
+++ b/tests/unit/services/test_base_service.py
@@ -1,0 +1,46 @@
+from django.test import TransactionTestCase
+from django.db import connection
+from apps.common.repositories.base import BaseRepository
+from apps.common.services.base import BaseService
+from conftest import TestModel
+
+
+class TestBaseRepository(BaseRepository[TestModel]):
+    model = TestModel
+
+
+class TestBaseService(BaseService[TestModel]):
+    repository_class = TestBaseRepository
+
+
+class TestBaseServiceImplementation(TransactionTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        connection.disable_constraint_checking()
+        with connection.schema_editor() as schema_editor:
+            schema_editor.create_model(TestModel)
+        connection.enable_constraint_checking()
+
+    @classmethod
+    def tearDownClass(cls):
+        connection.disable_constraint_checking()
+        with connection.schema_editor() as schema_editor:
+            schema_editor.delete_model(TestModel)
+        connection.enable_constraint_checking()
+        super().tearDownClass()
+
+    def setUp(self):
+        self.service = TestBaseService()
+        TestModel.objects.all().delete()
+        self.instance = TestModel.objects.create(name="Test", description="Desc", is_active=True)
+
+    def test_get_by_id(self):
+        obj = self.service.get_by_id(self.instance.id)
+        self.assertEqual(obj, self.instance)
+
+    def test_create_and_delete(self):
+        obj = self.service.create(name="New", description="New", is_active=False)
+        self.assertIsNotNone(obj.id)
+        self.service.delete(obj)
+        self.assertFalse(TestModel.objects.filter(id=obj.id).exists())

--- a/tests/unit/services/test_user_service.py
+++ b/tests/unit/services/test_user_service.py
@@ -1,0 +1,35 @@
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+from apps.common.services.user_service import UserService
+
+User = get_user_model()
+
+
+class TestUserService(TestCase):
+    def setUp(self):
+        self.service = UserService()
+        self.user1 = User.objects.create_user(
+            username='user1', email='user1@example.com', password='pass', is_active=True
+        )
+        self.user2 = User.objects.create_user(
+            username='user2', email='user2@example.com', password='pass', is_active=False
+        )
+        self.staff = User.objects.create_user(
+            username='staff', email='staff@example.com', password='pass', is_staff=True
+        )
+
+    def test_get_active_users(self):
+        users = self.service.get_active_users()
+        self.assertIn(self.user1, users)
+        self.assertIn(self.staff, users)
+        self.assertNotIn(self.user2, users)
+
+    def test_get_staff_users(self):
+        users = self.service.get_staff_users()
+        self.assertEqual(users, [self.staff])
+
+    def test_create_and_update_user(self):
+        user = self.service.create(username='new', email='new@example.com', password='pass')
+        self.assertIsNotNone(user.id)
+        updated = self.service.update(user, first_name='First')
+        self.assertEqual(updated.first_name, 'First')


### PR DESCRIPTION
## Summary
- create a `core` app containing `User` and `UserProfile` models
- register custom user model in settings
- update `UserRepository` to use `get_user_model`
- add service layer with base and user services
- implement unit tests for models and services

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d8abb70f8832f8401bcab2cb3c3f4