### PR TITLE
Fix Pytest collection warning

### DIFF
--- a/tests/unit/services/test_base_service.py
+++ b/tests/unit/services/test_base_service.py
@@ -11,6 +11,7 @@ class TestBaseRepository(BaseRepository[TestModel]):
 
 class TestBaseService(BaseService[TestModel]):
     repository_class = TestBaseRepository
+    __test__ = False
 
 
 class TestBaseServiceImplementation(TransactionTestCase):


### PR DESCRIPTION
## Summary
- prevent `TestBaseService` from being collected as a test class

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d8f8a0148832f83afc4a17580dbb7