### PR TITLE
Clarify poetry usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,17 @@ pip install -r requirements/development.txt
 # Install Django and ASGI server
 pip install django uvicorn
 
+# Using Poetry
+The repository also contains a `pyproject.toml` so it can be managed with
+[Poetry](https://python-poetry.org/). No lock file is committed and the
+environment may not have network access. Running `poetry install` therefore
+attempts to download packages from PyPI and can fail. If that happens, install
+dependencies with the requirements file instead:
+
+```bash
+pip install -r requirements/development.txt
+```
+
 # Run the Project
 
 # Export dev settings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,20 +1,16 @@
-[project]
+[tool.poetry]
 name = "django-as-microservice-template"
 version = "0.1.0"
 description = ""
-authors = [
-    {name = "Amir H. Sadati",email = "eng.amirh.sadati@gmail.com"}
-]
-license = {text = "GPL-3.0"}
+authors = ["Amir H. Sadati <eng.amirh.sadati@gmail.com>"]
+license = "GPL-3.0"
 readme = "README.md"
-requires-python = ">=3.11,<4"
-dependencies = [
-    "django (>=5.2.3,<6.0.0)",
-    "django-environ (>=0.12.0,<0.13.0)",
-    "uvicorn (>=0.34.3,<0.35.0)"
-]
 
-[tool.poetry]
+[tool.poetry.dependencies]
+python = ">=3.11,<4"
+django = ">=5.2.3,<6.0.0"
+django-environ = ">=0.12.0,<0.13.0"
+uvicorn = ">=0.34.3,<0.35.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.4.0"


### PR DESCRIPTION
## Summary
- tweak pyproject to use `[tool.poetry]`
- clarify that `poetry install` may fail without network access and provide a pip-based workaround in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fad1abb48832f99775169f9af01dc